### PR TITLE
refactor: use get logger

### DIFF
--- a/jinahub/indexers/dbms/PostgreSQLDBMSIndexer/__init__.py
+++ b/jinahub/indexers/dbms/PostgreSQLDBMSIndexer/__init__.py
@@ -2,12 +2,13 @@ __copyright__ = "Copyright (c) 2021 Jina AI Limited. All rights reserved."
 __license__ = "Apache-2.0"
 
 from typing import Tuple, Generator, Dict
-import numpy as np
-from jina.logging.logger import JinaLogger
-from jina_commons.indexers.dump import export_dump_streaming
 
-from .postgreshandler import PostgreSQLDBMSHandler
+import numpy as np
 from jina import Executor, requests, DocumentArray
+
+from jina_commons import get_logger
+from jina_commons.indexers.dump import export_dump_streaming
+from .postgreshandler import PostgreSQLDBMSHandler
 
 
 class PostgreSQLDBMSIndexer(Executor):
@@ -42,7 +43,7 @@ class PostgreSQLDBMSIndexer(Executor):
         self.password = password
         self.database = database
         self.table = table
-        self.logger = JinaLogger(self.metas.name)
+        self.logger = get_logger(self)
         self.handler = PostgreSQLDBMSHandler(
             hostname=self.hostname,
             port=self.port,

--- a/jinahub/indexers/dbms/PostgreSQLDBMSIndexer/postgreshandler.py
+++ b/jinahub/indexers/dbms/PostgreSQLDBMSIndexer/postgreshandler.py
@@ -39,7 +39,7 @@ class PostgreSQLDBMSHandler:
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
-        self.logger = JinaLogger(self.__class__.__name__)
+        self.logger = JinaLogger('psq_handler')
         self.hostname = hostname
         self.port = port
         self.username = username

--- a/jinahub/indexers/query/compound/NumpyPostgresQueryIndexer/__init__.py
+++ b/jinahub/indexers/query/compound/NumpyPostgresQueryIndexer/__init__.py
@@ -7,6 +7,7 @@ from typing import Dict
 from jina import requests, DocumentArray, Executor
 from jina.logging.logger import JinaLogger
 
+from jina_commons import get_logger
 from jinahub.indexers.query.keyvalue.PostgreSQLQueryIndexer import (
     PostgreSQLQueryIndexer,
 )
@@ -20,7 +21,7 @@ class NumpyPostgresQueryIndexer(Executor):
         super().__init__(**kwargs)
         # when constructed from rolling update the dump_path is passed via a runtime_arg
         dump_path = dump_path or kwargs.get('runtime_args').get('dump_path')
-        self.logger = JinaLogger(self.metas.name)
+        self.logger = get_logger(self)
         self._kv_indexer = None
         self._vec_indexer = None
         if dump_path:

--- a/jinahub/indexers/query/keyvalue/FileQueryIndexer/__init__.py
+++ b/jinahub/indexers/query/keyvalue/FileQueryIndexer/__init__.py
@@ -5,6 +5,7 @@ from typing import Optional, Dict
 from jina import Executor, requests, DocumentArray, Document
 from jina.logging.logger import JinaLogger
 
+from jina_commons import get_logger
 from jina_commons.indexers.dump import import_metas
 from .file_writer import FileWriterMixin
 
@@ -38,7 +39,7 @@ class FileQueryIndexer(Executor, FileWriterMixin):
 
         self._start = 0
         self._page_size = mmap.ALLOCATIONGRANULARITY
-        self.logger = JinaLogger(self.runtime_args.name or 'FileQuery')
+        self.logger = get_logger(self)
 
         self.default_traversal_path = default_traversal_path
 

--- a/jinahub/indexers/query/keyvalue/PostgreSQLQueryIndexer/__init__.py
+++ b/jinahub/indexers/query/keyvalue/PostgreSQLQueryIndexer/__init__.py
@@ -7,6 +7,7 @@ import numpy as np
 from jina import Executor, requests, DocumentArray
 from jina.logging.logger import JinaLogger
 
+from jina_commons import get_logger
 from jinahub.indexers.dbms.PostgreSQLDBMSIndexer import PostgreSQLDBMSHandler
 
 
@@ -43,7 +44,7 @@ class PostgreSQLQueryIndexer(Executor):
         self.password = password
         self.database = database
         self.table = table
-        self.logger = JinaLogger('PostgreSQLQueryIndexer')
+        self.logger = get_logger(self)
         self.handler = PostgreSQLDBMSHandler(
             hostname=self.hostname,
             port=self.port,

--- a/jinahub/indexers/query/vector/AnnoyIndexer/__init__.py
+++ b/jinahub/indexers/query/vector/AnnoyIndexer/__init__.py
@@ -7,6 +7,8 @@ import numpy as np
 from annoy import AnnoyIndex
 from jina import Executor, requests, DocumentArray, Document
 from jina.logging.logger import JinaLogger
+
+from jina_commons import get_logger
 from jina_commons.indexers.dump import import_vectors
 
 
@@ -21,13 +23,13 @@ class AnnoyIndexer(Executor):
     """
 
     def __init__(
-            self,
-            top_k: int = 10,
-            metric: str = 'euclidean',
-            num_trees: int = 10,
-            dump_path: Optional[str] = None,
-            traverse_path: list = ['r'],
-            **kwargs,
+        self,
+        top_k: int = 10,
+        metric: str = 'euclidean',
+        num_trees: int = 10,
+        dump_path: Optional[str] = None,
+        traverse_path: list = ['r'],
+        **kwargs,
     ):
         """
         Initialize an AnnoyIndexer
@@ -45,7 +47,7 @@ class AnnoyIndexer(Executor):
         self.metric = metric
         self.num_trees = num_trees
         self.traverse_path = traverse_path
-        self.logger = JinaLogger(self.metas.name)
+        self.logger = get_logger(self)
         dump_path = dump_path or kwargs.get('runtime_args').get('dump_path')
         if dump_path is not None:
             self.logger.info('Start building "AnnoyIndexer" from dump data')
@@ -81,4 +83,6 @@ class AnnoyIndexer(Executor):
     @requests(on='/fill_embedding')
     def fill_embedding(self, query_da: DocumentArray, **kwargs):
         for doc in query_da:
-            doc.embedding = np.array(self._indexer.get_item_vector(int(self._doc_id_to_offset[str(doc.id)])))
+            doc.embedding = np.array(
+                self._indexer.get_item_vector(int(self._doc_id_to_offset[str(doc.id)]))
+            )

--- a/jinahub/indexers/query/vector/NumpyIndexer/__init__.py
+++ b/jinahub/indexers/query/vector/NumpyIndexer/__init__.py
@@ -6,6 +6,8 @@ from typing import Tuple, Dict
 import numpy as np
 from jina import Executor, requests, DocumentArray, Document
 from jina.logging.logger import JinaLogger
+
+from jina_commons import get_logger
 from jina_commons.indexers.dump import import_vectors
 
 """
@@ -21,7 +23,7 @@ class NumpyIndexer(Executor):
     def __init__(self, dump_path: str = None, default_top_k: int = 5, **kwargs):
         super().__init__(**kwargs)
         self.dump_path = dump_path or kwargs.get('runtime_args').get('dump_path')
-        self.logger = JinaLogger(self.runtime_args.name)
+        self.logger = get_logger(self)
         self.default_top_k = default_top_k
         if self.dump_path is not None:
             self.logger.info(f'Importing data from {self.dump_path}')


### PR DESCRIPTION
All executors/indexers should have the same naming convention for their loggers. I see some that use class name, or metas.name, or other strings. It should be unified