### PR TITLE
refactor: save doc not vec and metas in table

### DIFF
--- a/jinahub/indexers/storage/PostgreSQLStorage/__init__.py
+++ b/jinahub/indexers/storage/PostgreSQLStorage/__init__.py
@@ -11,6 +11,12 @@ from jina_commons.indexers.dump import export_dump_streaming
 from .postgreshandler import PostgreSQLHandler
 
 
+def doc_without_embedding(d: Document):
+    new_doc = Document(d, copy=True)
+    new_doc.ClearField('embedding')
+    return new_doc.SerializeToString()
+
+
 class PostgreSQLStorage(Executor):
     """:class:`PostgreSQLStorage` PostgreSQL-based Storage Indexer.
 
@@ -67,7 +73,7 @@ class PostgreSQLStorage(Executor):
             for rec in records:
                 doc = Document(bytes(rec[1]))
                 vec = doc.embedding
-                metas = self._doc_without_embedding(doc)
+                metas = doc_without_embedding(doc)
                 yield rec[0], vec, metas
 
     @property
@@ -163,10 +169,3 @@ class PostgreSQLStorage(Executor):
 
         with self.handler as postgres_handler:
             postgres_handler.search(docs.traverse_flat(traversal_paths))
-
-
-    @staticmethod
-    def _doc_without_embedding(d):
-        new_doc = Document(d, copy=True)
-        new_doc.ClearField('embedding')
-        return new_doc

--- a/jinahub/indexers/storage/PostgreSQLStorage/__init__.py
+++ b/jinahub/indexers/storage/PostgreSQLStorage/__init__.py
@@ -65,7 +65,7 @@ class PostgreSQLStorage(Executor):
             cursor.execute(f'SELECT * from {handler.table} ORDER BY ID')
             records = cursor.fetchall()
             for rec in records:
-                doc = Document(rec[1])
+                doc = Document(bytes(rec[1]))
                 vec = doc.embedding
                 metas = self._doc_without_embedding(doc)
                 yield rec[0], vec, metas

--- a/jinahub/indexers/storage/PostgreSQLStorage/postgreshandler.py
+++ b/jinahub/indexers/storage/PostgreSQLStorage/postgreshandler.py
@@ -87,8 +87,7 @@ class PostgreSQLHandler:
                 cursor.execute(
                     f'CREATE TABLE {self.table} ( \
                     ID VARCHAR PRIMARY KEY,  \
-                    VECS BYTEA,  \
-                    METAS BYTEA);'
+                    DOC BYTEA);'
                 )
                 self.logger.info('Successfully created table')
             except (Exception, psycopg2.Error) as error:
@@ -110,12 +109,11 @@ class PostgreSQLHandler:
         try:
             psycopg2.extras.execute_batch(
                 cursor,
-                f'INSERT INTO {self.table} (ID, VECS, METAS) VALUES (%s, %s, %s)',
+                f'INSERT INTO {self.table} (ID, DOC) VALUES (%s, %s)',
                 [
                     (
                         doc.id,
-                        doc.embedding.tobytes() if doc.embedding is not None else None,
-                        doc_without_embedding(doc),
+                        doc.SerializeToString(),
                     )
                     for doc in docs
                 ],
@@ -138,11 +136,10 @@ class PostgreSQLHandler:
         cursor = self.connection.cursor()
         psycopg2.extras.execute_batch(
             cursor,
-            f'UPDATE {self.table} SET VECS = %s, METAS = %s WHERE ID = %s',
+            f'UPDATE {self.table} SET DOC = %s WHERE ID = %s',
             [
                 (
-                    doc.embedding.tobytes() if doc.embedding is not None else None,
-                    doc_without_embedding(doc),
+                    doc.SerializeToString(),
                     doc.id,
                 )
                 for doc in docs
@@ -175,9 +172,9 @@ class PostgreSQLHandler:
         cursor = self.connection.cursor()
         for doc in docs:
             # retrieve metadata
-            cursor.execute(f'SELECT METAS FROM {self.table} WHERE ID = %s;', (doc.id,))
+            cursor.execute(f'SELECT DOC FROM {self.table} WHERE ID = %s;', (doc.id,))
             result = cursor.fetchone()
-            data = bytes(result[0])
+            data = result[0]
             retrieved_doc = Document(data)
             # how to assign all fields but embedding?
             doc.content = retrieved_doc.content

--- a/jinahub/indexers/storage/PostgreSQLStorage/postgreshandler.py
+++ b/jinahub/indexers/storage/PostgreSQLStorage/postgreshandler.py
@@ -174,11 +174,10 @@ class PostgreSQLHandler:
             # retrieve metadata
             cursor.execute(f'SELECT DOC FROM {self.table} WHERE ID = %s;', (doc.id,))
             result = cursor.fetchone()
-            data = result[0]
+            data = bytes(result[0])
             retrieved_doc = Document(data)
-            # how to assign all fields but embedding?
-            doc.content = retrieved_doc.content
-            doc.mime_type = doc.mime_type
+            retrieved_doc.pop('embedding')
+            doc.MergeFrom(retrieved_doc)
 
     def _close_connection(self, connection):
         # restore it to the pool

--- a/jinahub/indexers/storage/PostgreSQLStorage/tests/test_postgres_dbms.py
+++ b/jinahub/indexers/storage/PostgreSQLStorage/tests/test_postgres_dbms.py
@@ -26,7 +26,6 @@ def docker_compose(request):
 d_embedding = np.array([1, 1, 1, 1, 1, 1, 1])
 c_embedding = np.array([2, 2, 2, 2, 2, 2, 2])
 
-
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 compose_yml = os.path.abspath(os.path.join(cur_dir, 'docker-compose.yml'))
 
@@ -92,9 +91,9 @@ def validate_db_side(postgres_indexer, expected_data):
         record = cursor.fetchall()
         for i in range(len(expected_data)):
             np.testing.assert_equal(ids[i], str(record[i][0]))
-            doc=Document(bytes(record[i][1]))
+            doc = Document(bytes(record[i][1]))
             np.testing.assert_equal(vecs[i], doc.embedding)
-            #np.testing.assert_equal(metas[i], bytes(record[i][2]))
+            np.testing.assert_equal(metas[i], doc_without_embedding(doc))
 
 
 @pytest.mark.parametrize('docker_compose', [compose_yml], indirect=['docker_compose'])

--- a/jinahub/indexers/storage/PostgreSQLStorage/tests/test_postgres_dbms.py
+++ b/jinahub/indexers/storage/PostgreSQLStorage/tests/test_postgres_dbms.py
@@ -87,13 +87,14 @@ def validate_db_side(postgres_indexer, expected_data):
     with postgres_indexer.handler as handler:
         cursor = handler.connection.cursor()
         cursor.execute(
-            f'SELECT ID, VECS, METAS from {postgres_indexer.table} ORDER BY ID::int'
+            f'SELECT ID, DOC from {postgres_indexer.table} ORDER BY ID::int'
         )
         record = cursor.fetchall()
         for i in range(len(expected_data)):
             np.testing.assert_equal(ids[i], str(record[i][0]))
-            np.testing.assert_equal(vecs[i], np.frombuffer(record[i][1]))
-            np.testing.assert_equal(metas[i], bytes(record[i][2]))
+            doc=Document(bytes(record[i][1]))
+            np.testing.assert_equal(vecs[i], doc.embedding)
+            #np.testing.assert_equal(metas[i], bytes(record[i][2]))
 
 
 @pytest.mark.parametrize('docker_compose', [compose_yml], indirect=['docker_compose'])


### PR DESCRIPTION
Make the postgresql consistent with LMDB indexer, and also fix the data type issue of `np.frombuffer`